### PR TITLE
Add environment variable for tracking child processes

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -179,3 +179,10 @@ Whenever to use a more intrusive, faster unwinding algorithm; enabled by default
 
 Setting it to `0` will on average significantly slow down unwinding. This option
 is provided only for debugging purposes.
+
+### `MEMORY_PROFILER_TRACK_CHILD_PROCESSES`
+
+*Default: `0`*
+
+If set to `1`, bytehound will also track the memory allocations of child processes spawned by the
+profiled process.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -185,4 +185,9 @@ is provided only for debugging purposes.
 *Default: `0`*
 
 If set to `1`, bytehound will also track the memory allocations of child processes spawned by the
-profiled process.
+profiled process. This only applies to child processes spawned by the common `fork()` + `exec()`
+combination.
+
+Note that if you enable this, you should use a value with appropriates placeholders (like PID)
+in `MEMORY_PROFILER_OUTPUT`, so that the output filenames for the parent and child processes are
+different. Otherwise, they would overwrite each other's data.

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -469,47 +469,7 @@ fn test_basic() {
         ]
     ).assert_success();
 
-    let analysis = analyze( "basic", cwd.join( "memory-profiling-basic.dat" ) );
-    let mut iter = analysis.allocations_from_source( "basic.c" );
-
-    let a0 = iter.next().unwrap(); // malloc, leaked
-    let a1 = iter.next().unwrap(); // malloc, freed
-    let a2 = iter.next().unwrap(); // malloc, freed through realloc
-    let a3 = iter.next().unwrap(); // realloc
-    let a4 = iter.next().unwrap(); // calloc, freed
-    let a5 = iter.next().unwrap(); // posix_memalign, leaked
-
-    assert!( a0.deallocation.is_none() );
-    assert!( a1.deallocation.is_some() );
-    assert!( a2.deallocation.is_some() );
-    assert!( a3.deallocation.is_none() );
-    assert!( a4.deallocation.is_none() );
-    assert!( a5.deallocation.is_none() );
-
-    assert_eq!( a5.address % 65536, 0 );
-
-    assert!( a0.size < a1.size );
-    assert!( a1.size < a2.size );
-    assert!( a2.size < a3.size );
-    assert!( a3.size < a4.size );
-    assert!( a4.size < a5.size );
-
-    assert_eq!( a0.thread, a1.thread );
-    assert_eq!( a1.thread, a2.thread );
-    assert_eq!( a2.thread, a3.thread );
-    assert_eq!( a3.thread, a4.thread );
-    assert_eq!( a4.thread, a5.thread );
-
-    assert_eq!( a0.backtrace.last().unwrap().line.unwrap() + 1, a1.backtrace.last().unwrap().line.unwrap() );
-
-    assert_eq!( a0.chain_length, 1 );
-    assert_eq!( a1.chain_length, 1 );
-    assert_eq!( a2.chain_length, 2 );
-    assert_eq!( a3.chain_length, 2 );
-    assert_eq!( a4.chain_length, 1 );
-    assert_eq!( a5.chain_length, 1 );
-
-    assert_eq!( iter.next(), None );
+    check_allocations_basic_program(&cwd.join( "memory-profiling-basic.dat" ));
 }
 
 #[cfg(test)]
@@ -1283,6 +1243,7 @@ fn test_cross_thread_alloc_non_culled() {
 fn test_track_spawned_children() {
     let cwd = workdir();
 
+    compile_with_flags( "basic.c", &["-o", "basic"] );
     compile_with_flags( "spawn-child.c", &["-o", "spawn-child"] );
 
     run_on_target(
@@ -1292,18 +1253,63 @@ fn test_track_spawned_children() {
         &[
             ("LD_PRELOAD", preload_path().into_os_string()),
             ("MEMORY_PROFILER_LOG", "debug".into()),
-            ("MEMORY_PROFILER_TRACK_CHILD_PROCESSES", "1".into())
+            ("MEMORY_PROFILER_TRACK_CHILD_PROCESSES", "1".into()),
+            ("MEMORY_PROFILER_OUTPUT", "memory-profiling-%e.dat".into())
         ]
     ).assert_success();
 
-    eprintln!("cwd: {}", cwd.display());
+    check_allocations_basic_program(&cwd.join( "memory-profiling-basic.dat" ));
 
-    for entry in std::fs::read_dir(cwd).unwrap() {
-        let entry = entry.unwrap();
-        if entry.file_name().to_str().unwrap().starts_with("memory-profiling_ls") {
-            return;
-        }
-    }
+    let analysis = analyze( "spawn-child", cwd.join( "memory-profiling-spawn-child.dat" ));
+    let mut iter = analysis.allocations_from_source( "spawn-child.c" );
 
-    panic!("Memory profiling file for spawned process not found");
+    let a0 = iter.next().unwrap();
+    assert_eq!(a0.size, 10001);
+
+    let a1 = iter.next().unwrap();
+    assert_eq!(a1.size, 10003);
+}
+
+fn check_allocations_basic_program(path: &Path) {
+    let analysis = analyze( "basic", path );
+    let mut iter = analysis.allocations_from_source( "basic.c" );
+
+    let a0 = iter.next().unwrap(); // malloc, leaked
+    let a1 = iter.next().unwrap(); // malloc, freed
+    let a2 = iter.next().unwrap(); // malloc, freed through realloc
+    let a3 = iter.next().unwrap(); // realloc
+    let a4 = iter.next().unwrap(); // calloc, freed
+    let a5 = iter.next().unwrap(); // posix_memalign, leaked
+
+    assert!( a0.deallocation.is_none() );
+    assert!( a1.deallocation.is_some() );
+    assert!( a2.deallocation.is_some() );
+    assert!( a3.deallocation.is_none() );
+    assert!( a4.deallocation.is_none() );
+    assert!( a5.deallocation.is_none() );
+
+    assert_eq!( a5.address % 65536, 0 );
+
+    assert!( a0.size < a1.size );
+    assert!( a1.size < a2.size );
+    assert!( a2.size < a3.size );
+    assert!( a3.size < a4.size );
+    assert!( a4.size < a5.size );
+
+    assert_eq!( a0.thread, a1.thread );
+    assert_eq!( a1.thread, a2.thread );
+    assert_eq!( a2.thread, a3.thread );
+    assert_eq!( a3.thread, a4.thread );
+    assert_eq!( a4.thread, a5.thread );
+
+    assert_eq!( a0.backtrace.last().unwrap().line.unwrap() + 1, a1.backtrace.last().unwrap().line.unwrap() );
+
+    assert_eq!( a0.chain_length, 1 );
+    assert_eq!( a1.chain_length, 1 );
+    assert_eq!( a2.chain_length, 2 );
+    assert_eq!( a3.chain_length, 2 );
+    assert_eq!( a4.chain_length, 1 );
+    assert_eq!( a5.chain_length, 1 );
+
+    assert_eq!( iter.next(), None );
 }

--- a/integration-tests/test-programs/spawn-child.c
+++ b/integration-tests/test-programs/spawn-child.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+int main() {
+    usleep( 100000 );
+    malloc( 10001 );
+
+    pid_t pid = fork();
+    if( pid == 0 ) {
+        // Child
+        if (execl("/usr/bin/ls", "/usr/bin/ls", NULL) == -1) {
+            return 1;
+        }
+        return 0;
+    }
+
+    waitpid(pid, NULL, 0);
+    malloc( 10003 );
+
+    return 0;
+}

--- a/integration-tests/test-programs/spawn-child.c
+++ b/integration-tests/test-programs/spawn-child.c
@@ -9,7 +9,7 @@ int main() {
     pid_t pid = fork();
     if( pid == 0 ) {
         // Child
-        if (execl("/usr/bin/ls", "/usr/bin/ls", NULL) == -1) {
+        if (execl("./basic", "./basic", NULL) == -1) {
             return 1;
         }
         return 0;

--- a/preload/src/global.rs
+++ b/preload/src/global.rs
@@ -7,7 +7,7 @@ use std::thread;
 use crate::arc_lite::ArcLite;
 use crate::event::{InternalAllocationId, InternalEvent, send_event};
 use crate::spin_lock::{SpinLock, SpinLockGuard};
-use crate::syscall;
+use crate::{opt, syscall};
 use crate::unwind::{ThreadUnwindState, prepare_to_start_unwinding};
 use crate::timestamp::Timestamp;
 use crate::allocation_tracker::AllocationTracker;
@@ -553,7 +553,9 @@ fn initialize_stage_2() {
     crate::init::initialize_atexit_hook();
     crate::init::initialize_signal_handlers();
 
-    std::env::remove_var( "LD_PRELOAD" );
+    if !opt::get().track_child_processes {
+        std::env::remove_var( "LD_PRELOAD" );
+    }
 
     info!( "Stage 2 initialization finished" );
 }

--- a/preload/src/opt.rs
+++ b/preload/src/opt.rs
@@ -22,7 +22,8 @@ pub struct Opts {
     pub backtrace_cache_size_level_2: usize,
     pub cull_temporary_allocations: bool,
     pub temporary_allocation_lifetime_threshold: u64,
-    pub temporary_allocation_pending_threshold: Option< usize >
+    pub temporary_allocation_pending_threshold: Option< usize >,
+    pub track_child_processes: bool
 }
 
 static mut OPTS: Opts = Opts {
@@ -48,6 +49,7 @@ static mut OPTS: Opts = Opts {
     cull_temporary_allocations: false,
     temporary_allocation_lifetime_threshold: 10000,
     temporary_allocation_pending_threshold: None,
+    track_child_processes: false
 };
 
 trait ParseVar: Sized {
@@ -143,7 +145,9 @@ pub unsafe fn initialize() {
         "MEMORY_PROFILER_TEMPORARY_ALLOCATION_LIFETIME_THRESHOLD"
             => &mut opts.temporary_allocation_lifetime_threshold,
         "MEMORY_PROFILER_TEMPORARY_ALLOCATION_PENDING_THRESHOLD"
-            => &mut opts.temporary_allocation_pending_threshold
+            => &mut opts.temporary_allocation_pending_threshold,
+        "MEMORY_PROFILER_TRACK_CHILD_PROCESSES"
+            => &mut opts.track_child_processes
     }
 
     opts.is_initialized = true;


### PR DESCRIPTION
Hi! We want to add `bytehound` to the [`rustc-perf`](https://github.com/rust-lang/rustc-perf) suite for profiling the Rust compiler. However, the compiler is usually invoked through `cargo`, which executes many `rustc` child processes underneath. In theory this could be resolved with some `RUSTC_WRAPPER` hacks, but I thought that it would be better if we could directly teach `bytehound` to track child processes.

I'm not sure what is the interaction of the added flag with `MEMORY_PROFILER_OUTPUT`, if it's set to a single, fixed filepath without placeholders, then the profile could be overwritten by the child processes? But that's probably user error.