### PR TITLE
implement sallocx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 target
 target-docker
 **/*.rs.bk
+**/*~
 webui/.cache
 webui/.parcel-cache
 webui/dist
 webui/node_modules
 replay/replay
 replay/generated.inc
+integration-tests/test-programs/jemalloc/jemalloc-*/Cargo.lock

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -544,6 +544,11 @@ fn test_jemalloc_v05_prefixed() {
 }
 
 #[test]
+fn test_jemalloc_v05_sallocx() {
+    run_jemalloc_test( "jemalloc-v05-sallocx" );
+}
+
+#[test]
 fn test_jemalloc_v05_unprefixed() {
     run_jemalloc_test( "jemalloc-v05-unprefixed" );
 }

--- a/integration-tests/test-programs/jemalloc/jemalloc-common/src/lib.rs
+++ b/integration-tests/test-programs/jemalloc/jemalloc-common/src/lib.rs
@@ -1,7 +1,7 @@
 use std::alloc::Layout;
 use std::ptr::write_volatile;
 
-unsafe fn alloc( size: usize ) -> *mut u8 {
+pub unsafe fn alloc( size: usize ) -> *mut u8 {
     let pointer = std::alloc::alloc( Layout::from_size_align( size, 1 ).unwrap() );
     write_volatile( pointer, 1 );
     pointer

--- a/integration-tests/test-programs/jemalloc/jemalloc-v05-sallocx/Cargo.toml
+++ b/integration-tests/test-programs/jemalloc/jemalloc-v05-sallocx/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "jemalloc-v05-sallocx"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+jemallocator = "0.5.0"
+jemalloc-sys = "0.5.0"
+jemalloc-common = { path = "../jemalloc-common" }
+
+[workspace]

--- a/integration-tests/test-programs/jemalloc/jemalloc-v05-sallocx/src/main.rs
+++ b/integration-tests/test-programs/jemalloc/jemalloc-v05-sallocx/src/main.rs
@@ -6,7 +6,9 @@ use jemalloc_sys::sallocx;
 fn main() {
     unsafe { jemalloc_common::run_test(); }
     unsafe {
-        let a8 = jemalloc_common::alloc( 10 );
-        assert_eq!( sallocx(a8 as _, 0), 16 );
+        let a7 = jemalloc_common::alloc( 1 );
+        assert_eq!( sallocx(a7 as _, 0), 8 );
+        let a8 = jemalloc_common::alloc( 12 );
+        assert_eq!( sallocx(a8 as _, 0), 8+8 );
     }
 }

--- a/integration-tests/test-programs/jemalloc/jemalloc-v05-sallocx/src/main.rs
+++ b/integration-tests/test-programs/jemalloc/jemalloc-v05-sallocx/src/main.rs
@@ -1,0 +1,12 @@
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+use jemalloc_sys::sallocx;
+
+fn main() {
+    unsafe { jemalloc_common::run_test(); }
+    unsafe {
+        let a8 = jemalloc_common::alloc( 10 );
+        assert_eq!( sallocx(a8 as _, 0), 16 );
+    }
+}

--- a/preload/src/api.rs
+++ b/preload/src/api.rs
@@ -51,6 +51,8 @@ extern "C" {
     fn jem_rallocx_real( old_pointer: *mut c_void, size: size_t, _flags: c_int ) -> *mut c_void;
     #[link_name = "_rjem_mp_xallocx"]
     fn jem_xallocx_real( pointer: *mut c_void, size: size_t, extra: size_t, _flags: c_int ) -> size_t;
+    #[link_name = "_rjem_mp_sallocx"]
+    fn jem_sallocx_real( pointer: *const c_void, _flags: c_int ) -> size_t;
     #[link_name = "_rjem_mp_nallocx"]
     fn jem_nallocx_real( size: size_t, _flags: c_int ) -> size_t;
     #[link_name = "_rjem_mp_malloc_usable_size"]
@@ -739,8 +741,9 @@ pub unsafe extern "C" fn _rjem_free( pointer: *mut c_void ) {
 }
 
 #[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn _rjem_sallocx( _pointer: *const c_void, _flags: c_int ) -> size_t {
-    todo!( "_rjem_sallocx" );
+pub unsafe extern "C" fn _rjem_sallocx( pointer: *const c_void, flags: c_int ) -> size_t {
+    debug_assert!( !pointer.is_null() );
+    jem_sallocx_real( pointer, flags ).checked_sub( mem::size_of::< InternalAllocationId >() ).expect("_rjem_sallocx: underflow")
 }
 
 #[cfg_attr(not(test), no_mangle)]


### PR DESCRIPTION
hello again!

i have made an attempt at `sallocx`. I don't know how to build a C test program with custom `_rjem_` prefix, so i copied existing v05 and call `jemalloc-sys` function in there. This requires `pub fn alloc` from the common directory.

about the test data, i don't understand how allocating 12 bytes, rounded up to 24:

```
  left: `24`,
 right: `16`', src/main.rs:12:9
```

naively, i thought `1->8`, so `12->16` as the closest byte-multiple.

ps i think the "jemalloc-v05-unprefixed" test is uncommitted somehow.