### PR TITLE
fix only not deallocated in current time range

### DIFF
--- a/cli-core/src/filter.rs
+++ b/cli-core/src/filter.rs
@@ -563,16 +563,11 @@ impl CompiledBasicFilter {
                 return false;
             }
 
-            if let Some( only_not_deallocated_after_at_least ) = self.only_not_deallocated_after_at_least {
-                if deallocation.timestamp >= only_not_deallocated_after_at_least {
-                    return false;
-                }
-            }
-
-            if let Some( only_not_deallocated_until_at_most ) = self.only_not_deallocated_until_at_most {
-                if deallocation.timestamp <= only_not_deallocated_until_at_most {
-                    return false;
-                }
+            match (self.only_not_deallocated_after_at_least, deallocation.timestamp, self.only_not_deallocated_until_at_most) {
+                (Some( l ), d, Some( r )) if l <= d && d <= r => return false,
+                (Some( l ), d, None) if l <= d => return false,
+                (None, d, Some( r )) if d <= r => return false,
+                _ => ()
             }
         }
 


### PR DESCRIPTION
not_deallocated_ fields designate the segment of the time line. We are
interested in the question whether our deallocation point falls outside
of this segment.

This means we *have* to check both ends of the segments to filter the point out,
so the current code which sequentially checks both ends can't work.

Let's write a match to more intuitively explain what we want here.

Basically, we want to forbid cases where `l, d, r` are in that order
(that is, `d` between `l` and `r`), so just code that up.

This is a follow up to https://github.com/koute/bytehound/commit/e981ea352c3a0dce25bb733ddd48e00549755d0d