### PR TITLE
fix build script error in newer yarn versions

### DIFF
--- a/server-core/build.rs
+++ b/server-core/build.rs
@@ -120,22 +120,19 @@ fn main() {
                 println!( "cargo:warning=You're using an ancient version of Yarn; this is unsupported" );
                 "node_modules/.bin".into()
             } else {
-                let mut bin_path = Command::new( yarn )
-                    .args( &[ "bin" ] )
+                let bin_path = Command::new( yarn )
+                    .args( &[ "bin", "parcel" ] )
                     .current_dir( &webui_dir )
                     .output()
                     .expect( "cannot launch a child process to get Yarn's bin directory" )
                     .stdout;
 
-                while bin_path.ends_with( b"\n" ) {
-                    bin_path.pop();
-                }
-
-                let bin_path = String::from_utf8( bin_path ).unwrap();
+                let path = String::from_utf8(bin_path).unwrap();
+                let bin_path = path.trim();
                 bin_path.into()
             };
 
-        let mut child = Command::new( bin_path.join( "parcel" ) )
+        let mut child = Command::new( bin_path )
             .args( &[
                 "build".into(),
                 "src/index.html".into(),

--- a/webui/package.json
+++ b/webui/package.json
@@ -33,6 +33,9 @@
     "reactdom": "^2.0.0",
     "reactstrap": "^6.2.0"
   },
+  "optionalDependencies": {
+    "@parcel/css-linux-arm64-gnu": "^1.13.1"
+  },
   "scripts": {
     "start": "parcel ./src/index.html",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This PR:
- fixes #107 where build scripts fails to find `parcel` executable
- add optional dependecy for `linux-arm64-gnu` platform. Missing this dependency will cause build failure.

This PR has been tested on `linux-x64-gnu` and `linux-arm64-gnu`, yarn `1.22.19` and `3.4.1`