### PR TITLE
Use memfd_create syscall instead of libc wrapper

### DIFF
--- a/preload/src/api.rs
+++ b/preload/src/api.rs
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn bytehound_mimalloc_raw_mmap( addr: *mut c_void, length:
     // Here we abuse the fact that an memfd-based map will have its name displayed in maps.
     //
     // It's nasty, but it works.
-    let fd = libc::memfd_create( name.as_ptr().cast(), libc::MFD_CLOEXEC );
+    let fd = syscall::memfd_create( name.as_ptr().cast(), libc::MFD_CLOEXEC );
     assert!( fd >= 0 );
     libc::ftruncate( fd, length as _ );
     fildes = fd;

--- a/preload/src/global.rs
+++ b/preload/src/global.rs
@@ -603,7 +603,7 @@ fn initialize_stage_1() {
     check_set_vma_anon_name();
     if !is_pr_set_vma_anon_name_supported() {
         unsafe {
-            let fd = libc::memfd_create( b"bytehound_padding\0".as_ptr().cast(), libc::MFD_CLOEXEC );
+            let fd = syscall::memfd_create( b"bytehound_padding\0".as_ptr().cast(), libc::MFD_CLOEXEC );
             if fd < 0 {
                 error!( "Failed to create a memfd for a dummy map!" );
                 libc::abort();

--- a/preload/src/syscall.rs
+++ b/preload/src/syscall.rs
@@ -18,6 +18,7 @@ macro_rules! syscall {
     (@to_libc MMAP2) => { libc::SYS_mmap2 };
     (@to_libc MUNMAP) => { libc::SYS_munmap };
     (@to_libc GETPID) => { libc::SYS_getpid };
+    (@to_libc MEMFD_CREATE) => { libc::SYS_memfd_create };
 
     ($num:ident) => {
         libc::syscall( syscall!( @to_libc $num ) )
@@ -166,4 +167,10 @@ pub unsafe fn pr_set_vma_anon_name( addr: *mut libc::c_void, length: usize, name
     );
 
     errcode >= 0
+}
+
+pub fn memfd_create( name: *const libc::c_char, flags: libc::c_uint ) -> libc::c_int {
+    unsafe {
+        syscall!( MEMFD_CREATE, name, flags ) as _
+    }
 }


### PR DESCRIPTION
This fixes issue #96; in particular, this change makes bytehound usable on CentOS/RHEL 7 (its 3.10-based kernel includes backported memfd_create support but its glibc based off 3.17 has no wrapper for it).